### PR TITLE
NENA-STA-010.3.0f cleanup

### DIFF
--- a/i3-adr.yaml
+++ b/i3-adr.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 info:
   title: IS-ADR Service
-  version: "1.0"
+  version: "1.0.1"
 servers:
   - url: http://localhost/Adr/v1
 paths:
@@ -55,7 +55,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'i3-common.yaml#/components/schemas/VersionsArray'
+                $ref: 'https://raw.githubusercontent.com/NENA911/i3-Common/refs/tags/v1.0.0/i3-common.yaml#/components/schemas/VersionsArray'
 components:
   schemas:
     AdditionalDataValue:

--- a/i3-adr.yaml
+++ b/i3-adr.yaml
@@ -20,7 +20,7 @@ paths:
             type: string
       responses:
         '200':
-          description: Additional Data found
+          description: Additional Data Found
           content:
             application/xml:
               schema:
@@ -51,7 +51,7 @@ paths:
       operationId: RetrieveVersions
       responses:
         '200':
-          description: Versions found
+          description: Versions Found
           content:
             application/json:
               schema:

--- a/i3-adr.yaml
+++ b/i3-adr.yaml
@@ -42,7 +42,7 @@ paths:
           description: Unspecified Error
   /Versions:
     servers:
-      - url: https://api.example.com/Adr
+      - url: https://localhost/Adr
         description: Override base path for Versions query
     get:
       tags:


### PR DESCRIPTION
* Increments API version to 1.0.1.
* Fixes cross-reference to i3-common.yaml to be OpenAPI valid URL. (pending tagging of i3-common repo.)
* Fixes api.example.com server to localhost.